### PR TITLE
chore: remove deprecated expo sdkVersion

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -6,5 +6,4 @@ export default (): ExpoConfig => ({
   version: '1.0.0',
   platforms: ['ios', 'android', 'web'],
   orientation: 'portrait',
-  sdkVersion: '50.0.0',
 });


### PR DESCRIPTION
## Summary
- remove outdated `sdkVersion` from Expo config to rely on package-managed version

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c496cfd9708323876f4a90775539ca