### PR TITLE
Improve family graph layout for unions

### DIFF
--- a/tests/familyLayout.test.ts
+++ b/tests/familyLayout.test.ts
@@ -37,4 +37,81 @@ describe('layoutFamilyGraph', () => {
     expect(parent!.y).toBeLessThan(focus!.y);
     expect(child!.y).toBeGreaterThan(focus!.y);
   });
+
+  it('creates union anchors and supports multiple unions', () => {
+    const people: PersonNode[] = [
+      { id: 'a', firstName: 'A', birthYear: 1980 },
+      { id: 'b', firstName: 'B', birthYear: 1981 },
+      { id: 'c', firstName: 'C', birthYear: 1982 },
+      { id: 'd', firstName: 'D' },
+      { id: 'e', firstName: 'E' },
+    ];
+    const edges: ParentChildEdge[] = [
+      { parentId: 'a', childId: 'd', role: 'bio' },
+      { parentId: 'b', childId: 'd', role: 'bio' },
+      { parentId: 'a', childId: 'e', role: 'bio' },
+      { parentId: 'c', childId: 'e', role: 'bio' },
+    ];
+    const unions = [
+      { id: 'u1', aId: 'a', bId: 'b', start: 2000 },
+      { id: 'u2', aId: 'a', bId: 'c', start: 2005 },
+    ];
+    const visibility: Visibility = {
+      maxUpGenerations: 5,
+      maxDownGenerations: 5,
+      showRoles: { step: true, guardian: false, foster: false },
+    };
+    const result = layoutFamilyGraph({
+      people,
+      edges,
+      unions,
+      focusId: 'a',
+      visibility,
+    });
+
+    const union1 = result.nodes.find((n) => n.id === 'u1' && n.union);
+    const union2 = result.nodes.find((n) => n.id === 'u2' && n.union);
+    expect(union1 && union2).toBeTruthy();
+
+    const edgeD = result.edges.find((e) => e.childId === 'd');
+    const edgeE = result.edges.find((e) => e.childId === 'e');
+    expect(edgeD?.parentId).toBe('u1');
+    expect(edgeE?.parentId).toBe('u2');
+
+    const childD = result.nodes.find((n) => n.id === 'd');
+    const childE = result.nodes.find((n) => n.id === 'e');
+    expect(childD?.x).toBe(union1!.x);
+    expect(childE?.x).toBe(union2!.x);
+
+    expect(result.nodes.filter((n) => n.id === 'a').length).toBe(1);
+  });
+
+  it('orders nodes by union start, birth year and name', () => {
+    const people: PersonNode[] = [
+      { id: 'a', firstName: 'Ann', birthYear: 1980 },
+      { id: 'b', firstName: 'Bob', birthYear: 1975 },
+      { id: 'c', firstName: 'Cal', birthYear: 1985 },
+    ];
+    const unions = [
+      { id: 'u1', aId: 'a', bId: 'b', start: 1990 },
+      { id: 'u2', aId: 'a', bId: 'c', start: 2005 },
+    ];
+    const visibility: Visibility = {
+      maxUpGenerations: 1,
+      maxDownGenerations: 1,
+      showRoles: { step: true, guardian: false, foster: false },
+    };
+    const result = layoutFamilyGraph({
+      people,
+      edges: [],
+      unions,
+      focusId: 'a',
+      visibility,
+    });
+    const layer0 = result.nodes
+      .filter((n) => n.layer === 0 && !n.union)
+      .sort((a, b) => a.x - b.x)
+      .map((n) => n.id);
+    expect(layer0).toEqual(['b', 'a', 'c']);
+  });
 });


### PR DESCRIPTION
## Summary
- Add union anchor nodes so children connect through union bands
- Render multiple unions per person on shared layers
- Order people within layers by union start date then birth name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c55e7785d08323a8ed1c463e004805